### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Potential fix for [https://github.com/ayiezac78/html-sentinel-shepherd/security/code-scanning/1](https://github.com/ayiezac78/html-sentinel-shepherd/security/code-scanning/1)

To fix the issue, you should add an explicit `permissions` block for the `build` job in `.github/workflows/release.yml`. This is best placed immediately after `runs-on: ubuntu-latest` within the `build:` job configuration. Since the build job appears to only check out code, install dependencies, run CI, and upload an artifact, it does not need write access and likely only requires read access to repository contents. Set `permissions: contents: read`. No other modifications are required and existing functionality will be preserved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow permissions configuration for enhanced security practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->